### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://organicit-prod.visualstudio.com/62c67ebe-13c2-49e4-88a0-830967933b55/43365f83-86d9-4a9b-b12a-294332879344/_apis/work/boardbadge/1ff45f1d-7774-472e-bb79-8a46d15c7e7a)](https://organicit-prod.visualstudio.com/62c67ebe-13c2-49e4-88a0-830967933b55/_boards/board/t/43365f83-86d9-4a9b-b12a-294332879344/Microsoft.RequirementCategory)
 # Allentown
 new beginnings
 testing


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#3](https://organicit-prod.visualstudio.com/62c67ebe-13c2-49e4-88a0-830967933b55/_workitems/edit/3). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.